### PR TITLE
Create endpoint

### DIFF
--- a/backend/src/main/java/com/pingpad/SecurityConfig.java
+++ b/backend/src/main/java/com/pingpad/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.pingpad;
 
 import com.pingpad.auth.OAuthSuccessHandler;
 import com.pingpad.auth.OAuthUserService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,12 +10,17 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
 @EnableWebMvc
-@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final OAuthUserService oAuthUserService;
     private final OAuthSuccessHandler oAuthSuccessHandler;
     private final CorsConfig corsConfig;
+
+    public SecurityConfig(OAuthUserService oAuthUserService, OAuthSuccessHandler oAuthSuccessHandler, CorsConfig corsConfig) {
+        this.oAuthUserService = oAuthUserService;
+        this.oAuthSuccessHandler = oAuthSuccessHandler;
+        this.corsConfig = corsConfig;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/backend/src/main/java/com/pingpad/UserController.java
+++ b/backend/src/main/java/com/pingpad/UserController.java
@@ -2,7 +2,6 @@ package com.pingpad;
 
 import com.pingpad.models.User;
 import com.pingpad.repositories.UserRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,10 +10,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/user")
-@RequiredArgsConstructor
 public class UserController {
 
     private final UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @GetMapping("/me")
     public User getCurrentUser(Authentication authentication) {
@@ -25,4 +27,4 @@ public class UserController {
         }
         return null;
     }
-} 
+}

--- a/backend/src/main/java/com/pingpad/auth/OAuthUserService.java
+++ b/backend/src/main/java/com/pingpad/auth/OAuthUserService.java
@@ -2,7 +2,6 @@ package com.pingpad.auth;
 
 import com.pingpad.models.User;
 import com.pingpad.repositories.UserRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -15,10 +14,13 @@ import java.util.Collections;
 import java.util.Map;
 
 @Service
-@RequiredArgsConstructor
 public class OAuthUserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
+
+    public OAuthUserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {

--- a/backend/src/main/java/com/pingpad/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/pingpad/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.pingpad.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/backend/src/main/java/com/pingpad/controllers/ApiEndpointController.java
+++ b/backend/src/main/java/com/pingpad/controllers/ApiEndpointController.java
@@ -1,0 +1,194 @@
+package com.pingpad.controllers;
+
+import com.pingpad.dto.ApiEndpointResponse;
+import com.pingpad.dto.ApiTestResultResponse;
+import com.pingpad.dto.CreateApiEndpointRequest;
+import com.pingpad.models.ApiEndpoint;
+import com.pingpad.models.ApiTestResult;
+import com.pingpad.models.User;
+import com.pingpad.repositories.ApiEndpointRepository;
+import com.pingpad.repositories.ApiTestResultRepository;
+import com.pingpad.repositories.UserRepository;
+import com.pingpad.services.ApiTestingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/endpoints")
+public class ApiEndpointController {
+
+    private final ApiEndpointRepository apiEndpointRepository;
+    private final ApiTestResultRepository apiTestResultRepository;
+    private final UserRepository userRepository;
+    private final ApiTestingService apiTestingService;
+
+    public ApiEndpointController(ApiEndpointRepository apiEndpointRepository, 
+                                ApiTestResultRepository apiTestResultRepository, 
+                                UserRepository userRepository, 
+                                ApiTestingService apiTestingService) {
+        this.apiEndpointRepository = apiEndpointRepository;
+        this.apiTestResultRepository = apiTestResultRepository;
+        this.userRepository = userRepository;
+        this.apiTestingService = apiTestingService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ApiEndpointResponse>> getUserEndpoints(Authentication authentication) {
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        List<ApiEndpoint> endpoints = apiEndpointRepository.findByUserOrderByCreatedAtDesc(user);
+        List<ApiEndpointResponse> response = endpoints.stream()
+                .map(ApiEndpointResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiEndpointResponse> createEndpoint(
+            @RequestBody CreateApiEndpointRequest request,
+            Authentication authentication) {
+        
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        ApiEndpoint endpoint = new ApiEndpoint();
+        endpoint.setUser(user);
+        endpoint.setName(request.getName());
+        endpoint.setUrl(request.getUrl());
+        endpoint.setMethod(request.getMethod());
+        endpoint.setHeaders(request.getHeaders());
+        endpoint.setBody(request.getBody());
+
+        ApiEndpoint savedEndpoint = apiEndpointRepository.save(endpoint);
+        return ResponseEntity.ok(ApiEndpointResponse.fromEntity(savedEndpoint));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiEndpointResponse> getEndpoint(
+            @PathVariable Long id,
+            Authentication authentication) {
+        
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Optional<ApiEndpoint> endpoint = apiEndpointRepository.findById(id);
+        if (endpoint.isEmpty() || !endpoint.get().getUser().getId().equals(user.getId())) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(ApiEndpointResponse.fromEntity(endpoint.get()));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiEndpointResponse> updateEndpoint(
+            @PathVariable Long id,
+            @RequestBody CreateApiEndpointRequest request,
+            Authentication authentication) {
+        
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Optional<ApiEndpoint> optionalEndpoint = apiEndpointRepository.findById(id);
+        if (optionalEndpoint.isEmpty() || !optionalEndpoint.get().getUser().getId().equals(user.getId())) {
+            return ResponseEntity.notFound().build();
+        }
+
+        ApiEndpoint endpoint = optionalEndpoint.get();
+        endpoint.setName(request.getName());
+        endpoint.setUrl(request.getUrl());
+        endpoint.setMethod(request.getMethod());
+        endpoint.setHeaders(request.getHeaders());
+        endpoint.setBody(request.getBody());
+
+        ApiEndpoint savedEndpoint = apiEndpointRepository.save(endpoint);
+        return ResponseEntity.ok(ApiEndpointResponse.fromEntity(savedEndpoint));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEndpoint(
+            @PathVariable Long id,
+            Authentication authentication) {
+        
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Optional<ApiEndpoint> endpoint = apiEndpointRepository.findById(id);
+        if (endpoint.isEmpty() || !endpoint.get().getUser().getId().equals(user.getId())) {
+            return ResponseEntity.notFound().build();
+        }
+
+        apiEndpointRepository.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/test")
+    public ResponseEntity<ApiTestResultResponse> testEndpoint(
+            @PathVariable Long id,
+            Authentication authentication) {
+        
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Optional<ApiEndpoint> optionalEndpoint = apiEndpointRepository.findById(id);
+        if (optionalEndpoint.isEmpty() || !optionalEndpoint.get().getUser().getId().equals(user.getId())) {
+            return ResponseEntity.notFound().build();
+        }
+
+        ApiEndpoint endpoint = optionalEndpoint.get();
+        ApiTestResult result = apiTestingService.testEndpoint(endpoint, user);
+        
+        return ResponseEntity.ok(ApiTestResultResponse.fromEntity(result));
+    }
+
+    @GetMapping("/{id}/results")
+    public ResponseEntity<List<ApiTestResultResponse>> getEndpointResults(
+            @PathVariable Long id,
+            Authentication authentication) {
+        
+        User user = getCurrentUser(authentication);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        Optional<ApiEndpoint> endpoint = apiEndpointRepository.findById(id);
+        if (endpoint.isEmpty() || !endpoint.get().getUser().getId().equals(user.getId())) {
+            return ResponseEntity.notFound().build();
+        }
+
+        List<ApiTestResult> results = apiTestResultRepository.findByApiEndpointIdOrderByTimestampDesc(id);
+        List<ApiTestResultResponse> response = results.stream()
+                .map(ApiTestResultResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+
+    private User getCurrentUser(Authentication authentication) {
+        if (authentication != null && authentication.getPrincipal() instanceof OAuth2User) {
+            OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+            String githubLogin = oAuth2User.getAttribute("login");
+            return userRepository.findByGithubLogin(githubLogin).orElse(null);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/pingpad/dto/ApiEndpointResponse.java
+++ b/backend/src/main/java/com/pingpad/dto/ApiEndpointResponse.java
@@ -1,0 +1,68 @@
+package com.pingpad.dto;
+
+import com.pingpad.models.ApiEndpoint;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class ApiEndpointResponse {
+    private Long id;
+    private String name;
+    private String url;
+    private ApiEndpoint.HttpMethod method;
+    private Map<String, String> headers;
+    private String body;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructors
+    public ApiEndpointResponse() {}
+
+    public ApiEndpointResponse(Long id, String name, String url, ApiEndpoint.HttpMethod method, Map<String, String> headers, String body, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
+        this.method = method;
+        this.headers = headers;
+        this.body = body;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+
+    public ApiEndpoint.HttpMethod getMethod() { return method; }
+    public void setMethod(ApiEndpoint.HttpMethod method) { this.method = method; }
+
+    public Map<String, String> getHeaders() { return headers; }
+    public void setHeaders(Map<String, String> headers) { this.headers = headers; }
+
+    public String getBody() { return body; }
+    public void setBody(String body) { this.body = body; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+
+    public static ApiEndpointResponse fromEntity(ApiEndpoint endpoint) {
+        ApiEndpointResponse response = new ApiEndpointResponse();
+        response.setId(endpoint.getId());
+        response.setName(endpoint.getName());
+        response.setUrl(endpoint.getUrl());
+        response.setMethod(endpoint.getMethod());
+        response.setHeaders(endpoint.getHeaders());
+        response.setBody(endpoint.getBody());
+        response.setCreatedAt(endpoint.getCreatedAt());
+        response.setUpdatedAt(endpoint.getUpdatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/pingpad/dto/ApiTestResultResponse.java
+++ b/backend/src/main/java/com/pingpad/dto/ApiTestResultResponse.java
@@ -1,0 +1,68 @@
+package com.pingpad.dto;
+
+import com.pingpad.models.ApiTestResult;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class ApiTestResultResponse {
+    private Long id;
+    private Long endpointId;
+    private Integer statusCode;
+    private Long responseTime;
+    private String responseBody;
+    private Map<String, String> responseHeaders;
+    private String error;
+    private LocalDateTime timestamp;
+
+    // Constructors
+    public ApiTestResultResponse() {}
+
+    public ApiTestResultResponse(Long id, Long endpointId, Integer statusCode, Long responseTime, String responseBody, Map<String, String> responseHeaders, String error, LocalDateTime timestamp) {
+        this.id = id;
+        this.endpointId = endpointId;
+        this.statusCode = statusCode;
+        this.responseTime = responseTime;
+        this.responseBody = responseBody;
+        this.responseHeaders = responseHeaders;
+        this.error = error;
+        this.timestamp = timestamp;
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getEndpointId() { return endpointId; }
+    public void setEndpointId(Long endpointId) { this.endpointId = endpointId; }
+
+    public Integer getStatusCode() { return statusCode; }
+    public void setStatusCode(Integer statusCode) { this.statusCode = statusCode; }
+
+    public Long getResponseTime() { return responseTime; }
+    public void setResponseTime(Long responseTime) { this.responseTime = responseTime; }
+
+    public String getResponseBody() { return responseBody; }
+    public void setResponseBody(String responseBody) { this.responseBody = responseBody; }
+
+    public Map<String, String> getResponseHeaders() { return responseHeaders; }
+    public void setResponseHeaders(Map<String, String> responseHeaders) { this.responseHeaders = responseHeaders; }
+
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+
+    public static ApiTestResultResponse fromEntity(ApiTestResult result) {
+        ApiTestResultResponse response = new ApiTestResultResponse();
+        response.setId(result.getId());
+        response.setEndpointId(result.getApiEndpoint().getId());
+        response.setStatusCode(result.getStatusCode());
+        response.setResponseTime(result.getResponseTime());
+        response.setResponseBody(result.getResponseBody());
+        response.setResponseHeaders(result.getResponseHeaders());
+        response.setError(result.getError());
+        response.setTimestamp(result.getTimestamp());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/pingpad/dto/CreateApiEndpointRequest.java
+++ b/backend/src/main/java/com/pingpad/dto/CreateApiEndpointRequest.java
@@ -1,0 +1,39 @@
+package com.pingpad.dto;
+
+import com.pingpad.models.ApiEndpoint;
+import java.util.Map;
+
+public class CreateApiEndpointRequest {
+    private String name;
+    private String url;
+    private ApiEndpoint.HttpMethod method;
+    private Map<String, String> headers;
+    private String body;
+
+    // Constructors
+    public CreateApiEndpointRequest() {}
+
+    public CreateApiEndpointRequest(String name, String url, ApiEndpoint.HttpMethod method, Map<String, String> headers, String body) {
+        this.name = name;
+        this.url = url;
+        this.method = method;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    // Getters and Setters
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+
+    public ApiEndpoint.HttpMethod getMethod() { return method; }
+    public void setMethod(ApiEndpoint.HttpMethod method) { this.method = method; }
+
+    public Map<String, String> getHeaders() { return headers; }
+    public void setHeaders(Map<String, String> headers) { this.headers = headers; }
+
+    public String getBody() { return body; }
+    public void setBody(String body) { this.body = body; }
+}

--- a/backend/src/main/java/com/pingpad/models/ApiEndpoint.java
+++ b/backend/src/main/java/com/pingpad/models/ApiEndpoint.java
@@ -1,0 +1,100 @@
+package com.pingpad.models;
+
+import jakarta.persistence.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "api_endpoints")
+public class ApiEndpoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private HttpMethod method;
+
+    @ElementCollection
+    @CollectionTable(name = "api_endpoint_headers", joinColumns = @JoinColumn(name = "endpoint_id"))
+    @MapKeyColumn(name = "header_key")
+    @Column(name = "header_value")
+    private Map<String, String> headers;
+
+    @Column(columnDefinition = "TEXT")
+    private String body;
+
+    @DateTimeFormat
+    private LocalDateTime createdAt;
+
+    @DateTimeFormat
+    private LocalDateTime updatedAt;
+
+    // Constructors
+    public ApiEndpoint() {}
+
+    public ApiEndpoint(User user, String name, String url, HttpMethod method, Map<String, String> headers, String body) {
+        this.user = user;
+        this.name = name;
+        this.url = url;
+        this.method = method;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+
+    public HttpMethod getMethod() { return method; }
+    public void setMethod(HttpMethod method) { this.method = method; }
+
+    public Map<String, String> getHeaders() { return headers; }
+    public void setHeaders(Map<String, String> headers) { this.headers = headers; }
+
+    public String getBody() { return body; }
+    public void setBody(String body) { this.body = body; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+
+    public enum HttpMethod {
+        GET, POST, PUT, DELETE, PATCH
+    }
+}

--- a/backend/src/main/java/com/pingpad/models/ApiTestResult.java
+++ b/backend/src/main/java/com/pingpad/models/ApiTestResult.java
@@ -1,0 +1,84 @@
+package com.pingpad.models;
+
+import jakarta.persistence.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "api_test_results")
+public class ApiTestResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "endpoint_id", nullable = false)
+    private ApiEndpoint apiEndpoint;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private Integer statusCode;
+
+    private Long responseTime;
+
+    @Column(columnDefinition = "TEXT")
+    private String responseBody;
+
+    @ElementCollection
+    @CollectionTable(name = "api_test_result_headers", joinColumns = @JoinColumn(name = "result_id"))
+    @MapKeyColumn(name = "header_key")
+    @Column(name = "header_value")
+    private Map<String, String> responseHeaders;
+
+    @Column(columnDefinition = "TEXT")
+    private String error;
+
+    @DateTimeFormat
+    private LocalDateTime timestamp;
+
+    // Constructors
+    public ApiTestResult() {}
+
+    public ApiTestResult(ApiEndpoint apiEndpoint, User user) {
+        this.apiEndpoint = apiEndpoint;
+        this.user = user;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        timestamp = LocalDateTime.now();
+    }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public ApiEndpoint getApiEndpoint() { return apiEndpoint; }
+    public void setApiEndpoint(ApiEndpoint apiEndpoint) { this.apiEndpoint = apiEndpoint; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Integer getStatusCode() { return statusCode; }
+    public void setStatusCode(Integer statusCode) { this.statusCode = statusCode; }
+
+    public Long getResponseTime() { return responseTime; }
+    public void setResponseTime(Long responseTime) { this.responseTime = responseTime; }
+
+    public String getResponseBody() { return responseBody; }
+    public void setResponseBody(String responseBody) { this.responseBody = responseBody; }
+
+    public Map<String, String> getResponseHeaders() { return responseHeaders; }
+    public void setResponseHeaders(Map<String, String> responseHeaders) { this.responseHeaders = responseHeaders; }
+
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+}

--- a/backend/src/main/java/com/pingpad/models/User.java
+++ b/backend/src/main/java/com/pingpad/models/User.java
@@ -1,21 +1,15 @@
 package com.pingpad.models;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 @Table(name = "users")
 public class User {
 
-    @jakarta.persistence.Id
+    @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -28,6 +22,15 @@ public class User {
     @DateTimeFormat
     private LocalDateTime updatedAt;
 
+    // Constructors
+    public User() {}
+
+    public User(String name, String githubLogin, String email) {
+        this.name = name;
+        this.githubLogin = githubLogin;
+        this.email = email;
+    }
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
@@ -38,4 +41,23 @@ public class User {
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getGithubLogin() { return githubLogin; }
+    public void setGithubLogin(String githubLogin) { this.githubLogin = githubLogin; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
 }

--- a/backend/src/main/java/com/pingpad/repositories/ApiEndpointRepository.java
+++ b/backend/src/main/java/com/pingpad/repositories/ApiEndpointRepository.java
@@ -1,0 +1,12 @@
+package com.pingpad.repositories;
+
+import com.pingpad.models.ApiEndpoint;
+import com.pingpad.models.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ApiEndpointRepository extends JpaRepository<ApiEndpoint, Long> {
+    List<ApiEndpoint> findByUserOrderByCreatedAtDesc(User user);
+    List<ApiEndpoint> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/backend/src/main/java/com/pingpad/repositories/ApiTestResultRepository.java
+++ b/backend/src/main/java/com/pingpad/repositories/ApiTestResultRepository.java
@@ -1,0 +1,13 @@
+package com.pingpad.repositories;
+
+import com.pingpad.models.ApiTestResult;
+import com.pingpad.models.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ApiTestResultRepository extends JpaRepository<ApiTestResult, Long> {
+    List<ApiTestResult> findByUserOrderByTimestampDesc(User user);
+    List<ApiTestResult> findByUserIdOrderByTimestampDesc(Long userId);
+    List<ApiTestResult> findByApiEndpointIdOrderByTimestampDesc(Long endpointId);
+}

--- a/backend/src/main/java/com/pingpad/services/ApiTestingService.java
+++ b/backend/src/main/java/com/pingpad/services/ApiTestingService.java
@@ -1,0 +1,123 @@
+package com.pingpad.services;
+
+import com.pingpad.models.ApiEndpoint;
+import com.pingpad.models.ApiTestResult;
+import com.pingpad.models.User;
+import com.pingpad.repositories.ApiTestResultRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class ApiTestingService {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiTestingService.class);
+    
+    private final ApiTestResultRepository apiTestResultRepository;
+    private final RestTemplate restTemplate;
+
+    public ApiTestingService(ApiTestResultRepository apiTestResultRepository, RestTemplate restTemplate) {
+        this.apiTestResultRepository = apiTestResultRepository;
+        this.restTemplate = restTemplate;
+    }
+
+    public ApiTestResult testEndpoint(ApiEndpoint endpoint, User user) {
+        long startTime = System.currentTimeMillis();
+        ApiTestResult result = new ApiTestResult();
+        result.setApiEndpoint(endpoint);
+        result.setUser(user);
+
+        log.info("Testing endpoint: {} with method: {}", endpoint.getUrl(), endpoint.getMethod());
+
+        try {
+            // Prepare headers
+            HttpHeaders headers = new HttpHeaders();
+            if (endpoint.getHeaders() != null) {
+                endpoint.getHeaders().forEach(headers::set);
+                log.info("Headers set: {}", endpoint.getHeaders());
+            }
+
+            // Prepare request entity
+            HttpEntity<String> requestEntity = new HttpEntity<>(endpoint.getBody(), headers);
+
+            // Make the HTTP request
+            log.info("Making HTTP request to: {}", endpoint.getUrl());
+            ResponseEntity<String> response = restTemplate.exchange(
+                endpoint.getUrl(),
+                HttpMethod.valueOf(endpoint.getMethod().name()),
+                requestEntity,
+                String.class
+            );
+
+            long endTime = System.currentTimeMillis();
+
+            // Set successful response data
+            result.setStatusCode(response.getStatusCode().value());
+            result.setResponseTime(endTime - startTime);
+            result.setResponseBody(response.getBody());
+            
+            log.info("Response received - Status: {}, Response time: {}ms, Body length: {}", 
+                response.getStatusCode().value(), endTime - startTime, 
+                response.getBody() != null ? response.getBody().length() : 0);
+            
+            // Convert response headers to Map
+            Map<String, String> responseHeaders = new HashMap<>();
+            response.getHeaders().forEach((key, values) -> 
+                responseHeaders.put(key, String.join(", ", values))
+            );
+            result.setResponseHeaders(responseHeaders);
+
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            long endTime = System.currentTimeMillis();
+            
+            log.warn("HTTP error response: {} - {}", e.getStatusCode().value(), e.getMessage());
+            
+            // Handle HTTP error responses (4xx, 5xx)
+            result.setStatusCode(e.getStatusCode().value());
+            result.setResponseTime(endTime - startTime);
+            result.setResponseBody(e.getResponseBodyAsString());
+            result.setError(e.getMessage());
+
+            // Convert response headers to Map
+            Map<String, String> responseHeaders = new HashMap<>();
+            if (e.getResponseHeaders() != null) {
+                e.getResponseHeaders().forEach((key, values) -> 
+                    responseHeaders.put(key, String.join(", ", values))
+                );
+            }
+            result.setResponseHeaders(responseHeaders);
+
+        } catch (ResourceAccessException e) {
+            long endTime = System.currentTimeMillis();
+            
+            log.error("Connection error: {}", e.getMessage());
+            
+            // Handle connection/timeout errors
+            result.setResponseTime(endTime - startTime);
+            result.setError("Connection error: " + e.getMessage());
+
+        } catch (Exception e) {
+            long endTime = System.currentTimeMillis();
+            
+            log.error("Unexpected error testing endpoint {}: {}", endpoint.getUrl(), e.getMessage(), e);
+            
+            // Handle other errors
+            result.setResponseTime(endTime - startTime);
+            result.setError("Unexpected error: " + e.getMessage());
+        }
+
+        // Save and return the result
+        log.info("Saving test result - Status: {}, Response time: {}ms, Error: {}", 
+            result.getStatusCode(), result.getResponseTime(), result.getError());
+        
+        return apiTestResultRepository.save(result);
+    }
+}


### PR DESCRIPTION
closes #6 

# What I did
- API for creating-endpoint
- New collections for api_endpoint, api_endpoint_headers, api_test_results, api_test_headers

# Why
- Create endpoint through frontend, register in backend & DB
- store headers in separate db collection as we might want different headers for same endpoint 